### PR TITLE
Fixed Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn add msal-vue
 ## Usage
 
 ```ts
-import MsalPlugin from 'msal-vue'
+import { MsalPlugin } from 'msal-vue'
  
 Vue.use(MsalPlugin, {
     auth: {


### PR DESCRIPTION
The plugin doesn't export as `default`. Docs implied that it did. Had me scratching my head when it didn't work. Just updated the docs.

Thanks for the plugin.