### PR TITLE
Allow for Logins via Redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 > By Braedon Wooding
 
 Because the alternatives are pretty mediocre... this is a very simple layer that has;
-- Typescript support
-- Error handling (i.e. if popup fails you can spawn a button to trigger popup, which is more likely to work if you are in some browsers)
-- Amongst just a cleaner implementation with less heavy dependencies (no lodash/axios dependency, only msal-browser)
+
+-   Typescript support
+-   Error handling (i.e. if popup fails you can spawn a button to trigger popup, which is more likely to work if you are in some browsers)
+-   Amongst just a cleaner implementation with less heavy dependencies (no lodash/axios dependency, only msal-browser)
 
 It however, is very lite in terms of extensive features, and doesn't explicitly support things like MSGraph.
 
 ## Installation
 
-Add the msal-vue dependency to your project using yarn or npm.  We require a peer dependency of Vue3.
+Add the msal-vue dependency to your project using yarn or npm. We require a peer dependency of Vue3.
 
 ```
 npm install msal-vue
@@ -28,22 +29,30 @@ yarn add msal-vue
 ## Usage
 
 ```ts
-import { MsalPlugin } from 'msal-vue'
- 
-Vue.use(MsalPlugin, {
-    auth: {
-        clientId: '<client id>',
-        authority: '<url>',
-        redirectUri: '<url>'
+import { MsalPlugin } from 'msal-vue';
+
+Vue.use(
+    MsalPlugin,
+    // MSAL configurations: https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#browserconfiguration
+    {
+        auth: {
+            clientId: '<client id>',
+            authority: '<url>',
+            redirectUri: '<url>',
+        },
+        cache: {
+            cacheLocation: 'localStorage', // Options are localStorage, sessionStorage, memoryStorage
+        },
     },
-    cache: {
-        cacheLocation: 'localStorage', // Options are localStorage, sessionStorage, memoryStorage
-    },
-});
- 
+    // Optional msal-vue specific configurations:
+    {
+        method: 'popup', // Options are 'popup' (default) and 'redirect'
+    }
+);
+
 new Vue({
-  // ... vue options as usual
-})
+    // ... vue options as usual
+});
 ```
 
 Configuration is as follows here: [Browser Configuration](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#browserconfiguration).
@@ -51,14 +60,23 @@ Configuration is as follows here: [Browser Configuration](https://azuread.github
 To authenticate it's as simple as follows.
 
 ```ts
-// Optional scope set can be passed
-// default is new ScopeSet(['user.read', 'openid', 'profile', 'email']\
+// There are three login options. You really should just use the first one.
+await this.$msal.login();
+// If you want to be explicit, you can use:
 await this.$msal.loginPopup();
-// returns an AuthenticationResult which is a standard type in MSAL
+// or...
+await this.$msal.loginRedirect();
+// Just know that if you have the method set to 'popup' and then call
+// `loginRedirect`, a MsalVueMethodError will be thrown.
+
+// On all the above methods, an optional scope set can be passed
+// default is new ScopeSet(['user.read', 'openid', 'profile', 'email']\
+
+// They all return an AuthenticationResult which is a standard type in MSAL
 // details here: https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#authenticationresult
 // but most likely you'll just want to access the `account`
 
-// at any time you can request for it to acquire a new token (in case of 401's)
+// At any time you can request for it to acquire a new token (in case of 401's)
 // as follows... takes in an optional scope set
 // default is just new ScopeSet(['user.read']) though
 await this.$msal.acquireToken();
@@ -69,16 +87,16 @@ const user = this.$msal.user();
 
 // are we authenticated?
 if (this.$msal.isAuthenticated()) {
-  // we can finally also forcefully logout
-  this.$msal.logout();
+    // we can finally also forcefully logout
+    this.$msal.logout();
 }
 ```
 
-That covers every bit of functionality in this.  The code itself is also quite readable and overall is just a light layer ontop of msal.
+That covers every bit of functionality in this. The code itself is also quite readable and overall is just a light layer ontop of msal.
 
 ### Advanced Usage
 
-You can access the underlying MSAL library through the `.instance` getter.  This gives you full access to MSAL.
+You can access the underlying MSAL library through the `.instance` getter. This gives you full access to MSAL.
 
 ## Nuxt Usage
 

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -16,7 +16,7 @@ export class MsalLayer {
     private method: string;
     private redirectUri: string | undefined;
 
-    public constructor(config: Configuration, customConfig: { method?: string | undefined; redirectUri?: string | undefined; } | undefined) {
+    public constructor(config: Configuration, customConfig: { method?: string | undefined } | undefined) {
         // msal-vue specific configuration items.
         this.method = customConfig?.method === 'redirect' ? 'redirect' : 'popup' ?? 'popup';
         this.redirectUri = config.auth.redirectUri;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -2,10 +2,25 @@ import { AuthenticationResult, Configuration, PublicClientApplication } from "@a
 import { PopupWindowAttributes } from "@azure/msal-browser/dist/utils/PopupUtils";
 import { AccountInfo, ScopeSet } from "@azure/msal-common";
 
+class MsalVueMethodError extends Error {
+    constructor(method: string) {
+        const methodName = `login${method.slice(0, 1).toUpperCase() + method.slice(1)}`;
+        const msg = `Method is set to '${method}', use ${methodName}() or login() instead.`;
+        super(msg);
+        this.name = 'MsalVueMethodError';
+    }
+}
+
 export class MsalLayer {
     private msalInstance: PublicClientApplication;
+    private method: string;
+    private redirectUri: string | undefined;
 
-    public constructor(config: Configuration) {
+    public constructor(config: Configuration, customConfig: { method?: string | undefined; redirectUri?: string | undefined; } | undefined) {
+        // msal-vue specific configuration items.
+        this.method = customConfig?.method === 'redirect' ? 'redirect' : 'popup' ?? 'popup';
+        this.redirectUri = config.auth.redirectUri;
+
         this.msalInstance = new PublicClientApplication(config);
     }
 
@@ -13,7 +28,19 @@ export class MsalLayer {
         return this.msalInstance;
     }
 
+    public async login(scopes: ScopeSet = new ScopeSet(['user.read', 'openid', 'profile', 'email']), popupConfig?: PopupWindowAttributes): Promise<AuthenticationResult | null> {
+        switch (this.method) {
+            case 'redirect':
+                return this.loginRedirect(scopes);
+            case 'popup':
+            default:
+                return this.loginPopup(scopes, popupConfig);
+        }
+    }
+
     public async loginPopup(scopes: ScopeSet = new ScopeSet(['user.read', 'openid', 'profile', 'email']), popupConfig?: PopupWindowAttributes): Promise<AuthenticationResult> {
+        if (this.method !== 'popup') throw new MsalVueMethodError(this.method);
+
         return await this.msalInstance.loginPopup({
             scopes: scopes.asArray(),
             popupWindowAttributes: popupConfig,
@@ -21,8 +48,23 @@ export class MsalLayer {
         });
     }
 
+    public async loginRedirect(scopes: ScopeSet = new ScopeSet(['user.read', 'openid', 'profile', 'email'])): Promise<AuthenticationResult | null> {
+        if (this.method !== 'redirect') throw new MsalVueMethodError(this.method);
+        if (!this.redirectUri) throw new Error('Redirect URI must be defined if using the "redirect" login method.');
+        
+        const response = await this.msalInstance.handleRedirectPromise();
+        await this.msalInstance.loginRedirect({
+            scopes: scopes.asArray(),
+            redirectUri: this.redirectUri,
+            prompt: "select_account"
+        });
+
+        return response;
+    }
+
     public async logout(): Promise<void> {
-        return await this.msalInstance.logoutPopup();
+        if (this.method === 'popup') return await this.msalInstance.logoutPopup();
+        return await this.msalInstance.logoutRedirect();
     }
 
     public user(): AccountInfo | undefined {
@@ -34,26 +76,38 @@ export class MsalLayer {
         return currentAccounts[0];
     }
 
-    public async acquireToken(scopes: ScopeSet = new ScopeSet(['user.read'])): Promise<AuthenticationResult> {
-        let resp: AuthenticationResult;
+    public async acquireToken(scopes: ScopeSet = new ScopeSet(['user.read'])): Promise<AuthenticationResult | null> {
+        let resp: AuthenticationResult | null;
 
         try {
             resp = await this.msalInstance.acquireTokenSilent({
                 scopes: scopes.asArray(),
                 account: this.user()
-            })
+            });
         } catch (err) {
-            // silent sometimes fails, so let's just try popup
-            resp = await this.msalInstance.acquireTokenPopup({
-                scopes: scopes.asArray(),
-                account: this.user()
-            })
+            // silent sometimes fails, so let's just try manual intervention
+            if (this.method === 'popup') {
+                resp = await this.msalInstance.acquireTokenPopup({
+                    scopes: scopes.asArray(),
+                    account: this.user()
+                });
+            } else {
+                if (!this.redirectUri) throw new Error('Could not acquire token: Redirect URI must be defined.');
+
+                resp = await this.msalInstance.handleRedirectPromise();
+                await this.msalInstance.acquireTokenRedirect({
+                    scopes: scopes.asArray(),
+                    account: this.user(),
+                    redirectUri: this.redirectUri,
+                });
+            }
         }
 
         return resp;
     }
 
-    public isAuthenticated(): boolean {
+    public async isAuthenticated(): Promise<boolean> {
+        if (this.method === 'redirect') await this.msalInstance.handleRedirectPromise();
         const accounts = this.msalInstance.getAllAccounts();
         return accounts && accounts.length > 0;
     }

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -9,7 +9,7 @@ declare module 'vue/types/vue' {
 }
 
 class MsalPlugin {
-    static install(Vue: VueConstructor<Vue>, options: Configuration, customConfig: { method?: string | undefined; redirectUri?: string | undefined; } | undefined): void {
+    static install(Vue: VueConstructor<Vue>, options: Configuration, customConfig: { method?: string | undefined } | undefined): void {
         Vue.prototype.$msal = new MsalLayer(options, customConfig);
     }
 }

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -9,8 +9,8 @@ declare module 'vue/types/vue' {
 }
 
 class MsalPlugin {
-    static install(Vue: VueConstructor<Vue>, options: Configuration): void {
-        Vue.prototype.$msal = new MsalLayer(options);
+    static install(Vue: VueConstructor<Vue>, options: Configuration, customConfig: { method?: string | undefined; redirectUri?: string | undefined; } | undefined): void {
+        Vue.prototype.$msal = new MsalLayer(options, customConfig);
     }
 }
 


### PR DESCRIPTION
* Added secondary configuration parameter for to the constructor of the plugin for `msal-vue`-specific configurations. User can now specify the method (popup or redirect) by passing in a `method` property.

  **Example:**
  ```javascript
  Vue.use(
      MsalPlugin,
      {
          auth: {
              clientId: '<client id>',
              authority: '<url>',
              redirectUri: '<url>',
          },
          cache: {
              cacheLocation: 'localStorage',
          },
      },
      // New (optional) configuration parameter for plugin-specific settings
      {
          method: 'redirect', // default is 'popup' if not specified
      }
  );
  ```

* Added new method: `loginRedirect()` that actually enables the ability to login using the `redirect` method.
* Added new method: `login()` that calls the correct login (`loginRedirect` or `loginPopup`) method based on configured method. It accepts the same parameters as `loginPopup()`.
* Updated documentation.